### PR TITLE
Add KopernicusSolarPanel as available panels

### DIFF
--- a/CleverSatCore.cfg
+++ b/CleverSatCore.cfg
@@ -78,8 +78,8 @@ name = Any
 type = Any
 	REQUIREMENT
 	{
-    name = PartModuleUnlocked
-    type = PartModuleUnlocked
+	name = PartModuleUnlocked
+	type = PartModuleUnlocked
 	partModule = ModuleDeployableSolarPanel
 	}
 	REQUIREMENT:NEEDS[NearFutureSolar]
@@ -87,6 +87,12 @@ type = Any
 	name = PartModuleUnlocked
 	type = PartModuleUnlocked
 	partModule = ModuleCurvedSolarPanel
+	}
+	REQUIREMENT:NEEDS[Kopernicus]
+	{
+	name = PartModuleUnlocked
+	type = PartModuleUnlocked
+	partModule = KopernicusSolarPanel
 	}
 }
 


### PR DESCRIPTION
If playing with Kopernicus, no satellite contracts would fire. This is a possible fix to #5, though more info is needed there.