### PR TITLE
Allow new Stayputnik and Kopernicus Solar Panels

### DIFF
--- a/CleverSatCore.cfg
+++ b/CleverSatCore.cfg
@@ -71,23 +71,28 @@ PARAMETER
 	completionText = calibration completed
 }
 
-
 REQUIREMENT
 {
 name = Any
 type = Any
-	REQUIREMENT
-	{
+    REQUIREMENT
+    {
     name = PartModuleUnlocked
     type = PartModuleUnlocked
-	partModule = ModuleDeployableSolarPanel
-	}
-	REQUIREMENT:NEEDS[NearFutureSolar]
-	{
-	name = PartModuleUnlocked
-	type = PartModuleUnlocked
-	partModule = ModuleCurvedSolarPanel
-	}
+    partModule = ModuleDeployableSolarPanel
+    }
+    REQUIREMENT:NEEDS[NearFutureSolar]
+    {
+    name = PartModuleUnlocked
+    type = PartModuleUnlocked
+    partModule = ModuleCurvedSolarPanel
+    }
+    REQUIREMENT:NEEDS[Kopernicus]
+    {
+    name = PartModuleUnlocked
+    type = PartModuleUnlocked
+    partModule = KopernicusSolarPanel
+    }
 }
 
 REQUIREMENT:NEEDS[RemoteTech]
@@ -101,9 +106,20 @@ REQUIREMENT:NEEDS[RemoteTech]
 
 REQUIREMENT
 {
-name = Probe
-type = PartUnlocked
-part = probeCoreSphere
+name = Any
+type = Any
+    REQUIREMENT
+    {
+    name = PartUnlocked
+    type = PartUnlocked
+    part = probeCoreSphere
+    }
+    REQUIREMENT
+    {
+    name = PartUnlocked
+    type = PartUnlocked
+    part = probeCoreSphere_v2
+    }
 }
 REQUIREMENT
 {


### PR DESCRIPTION
Allow for the initial satellite contracts to be generated with the requirement of the new, revamped Stayputnik part and also by allowing the use of Kopernicus solar panels.